### PR TITLE
feat(require-minimum-dependency-age): skip linting on Deno >= 2.9.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -54,6 +54,7 @@
   "imports": {
     "@std/collections": "jsr:@std/collections@^1.1.3",
     "@std/fmt": "jsr:@std/fmt@^1.0.8",
+    "@std/semver": "jsr:@std/semver@^1.0.8",
     "json-schema-to-typescript": "npm:json-schema-to-typescript@^15.0.4",
     "jsonc-parser": "npm:jsonc-parser@^3.3.1",
     "lines-and-columns": "npm:lines-and-columns@^2.0.4",

--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@std/collections@^1.1.3": "1.1.3",
     "jsr:@std/fmt@^1.0.8": "1.0.8",
+    "jsr:@std/semver@^1.0.8": "1.0.8",
     "npm:@types/node@*": "24.2.0",
     "npm:json-schema-to-typescript@^15.0.4": "15.0.4",
     "npm:jsonc-parser@^3.3.1": "3.3.1",
@@ -15,6 +16,9 @@
     },
     "@std/fmt@1.0.8": {
       "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
+    },
+    "@std/semver@1.0.8": {
+      "integrity": "dc830e8b8b6a380c895d53fbfd1258dc253704ca57bbe1629ac65fd7830179b7"
     }
   },
   "npm": {
@@ -121,6 +125,7 @@
     "dependencies": [
       "jsr:@std/collections@^1.1.3",
       "jsr:@std/fmt@^1.0.8",
+      "jsr:@std/semver@^1.0.8",
       "npm:json-schema-to-typescript@^15.0.4",
       "npm:jsonc-parser@^3.3.1",
       "npm:lines-and-columns@^2.0.4",

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -21,6 +21,7 @@ export interface LintOptions {
   include?: Array<string>;
   exclude?: Array<string>;
   config?: DenoJsonLintConfig;
+  denoVersion?: string;
 }
 
 interface LintAndFixResult {
@@ -67,6 +68,7 @@ function lintTree(
       rulesGroupedByPath[key].rules.push(rule);
     }
   }
+  const denoVersion = options?.denoVersion ?? Deno.version.deno;
   const diagnostics: Array<Diagnostic> = [];
   for (const [key, { rules, path }] of Object.entries(rulesGroupedByPath)) {
     const node = key === rootKey ? tree : findNodeAtLocation(tree, path);
@@ -77,6 +79,7 @@ function lintTree(
         : rule.defaultOptions;
       const context: LintContext = {
         options: maybeRuleOptions ?? rule.defaultOptions,
+        denoVersion,
         report(data) {
           const { node, ...problem } = data;
           const maybeLocation = node && lines.locationForIndex(node.offset);

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,3 +1,5 @@
+import { parse as parseSemver } from "@std/semver/parse";
+import { greaterOrEqual as semverGreaterOrEqual } from "@std/semver/greater-or-equal";
 import { parseArgsStringToArgv } from "string-argv";
 import type { EditResult, JSONPath, Node } from "jsonc-parser";
 import { findNodeAtLocation, getNodePath, getNodeValue } from "jsonc-parser";
@@ -22,6 +24,7 @@ interface LintReport {
 export interface LintContext<T = unknown> {
   report(data: LintReport): void;
   readonly options: T;
+  readonly denoVersion: string;
 }
 
 export interface LintRule<T = unknown> {
@@ -357,6 +360,11 @@ export const requireMinimumDependencyAge: LintRule = {
   ],
   lint(reporter, node) {
     if (node == null) {
+      const isMinimumDependencyAgeEnabledByDefault = semverGreaterOrEqual(
+        parseSemver(reporter.denoVersion),
+        parseSemver("2.9.0"),
+      );
+      if (isMinimumDependencyAgeEnabledByDefault) return;
       reporter.report({
         message: `\`${kMinimumDependencyAge}\` should be configured`,
       });

--- a/tests/rules/require-minimum-dependency-age.test.ts
+++ b/tests/rules/require-minimum-dependency-age.test.ts
@@ -1,10 +1,41 @@
 import assert from "node:assert/strict";
-import { applyFixes, lintAndFixText } from "../../src/lint.ts";
+import { applyFixes, lintAndFixText, lintText } from "../../src/lint.ts";
+import type { Diagnostic } from "../../src/lint.ts";
 
 Deno.test({
   name: "require-minimum-dependency-age",
   permissions: "none",
   fn: async (t) => {
+    await t.step(
+      "allows `minimumDependencyAge` to be omitted if the Deno version is greater than or equal to 2.9.0",
+      () => {
+        const given = "{}";
+        const actual = lintText(given, {
+          include: ["require-minimum-dependency-age"],
+          denoVersion: "2.9.0",
+        });
+        const expected: Array<Diagnostic> = [];
+        assert.deepEqual(actual, expected);
+      },
+    );
+
+    await t.step("encourages defining `minimumDependencyAge`", () => {
+      const given = "{}";
+      const actual = lintText(given, {
+        include: ["require-minimum-dependency-age"],
+        denoVersion: "2.8.3",
+      });
+      const expected: Array<Diagnostic> = [
+        {
+          id: "require-minimum-dependency-age",
+          message: "`minimumDependencyAge` should be configured",
+          line: undefined,
+          column: undefined,
+        },
+      ];
+      assert.deepEqual(actual, expected);
+    });
+
     await t.step("supports `--fix`", () => {
       const given = `{}`;
       const { fixes, unfixableDiagnostics } = lintAndFixText(given, {


### PR DESCRIPTION
NOTE: `minimumDependencyAge` is enabled by default starting in Deno 2.9.0.